### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,6 @@ jobs:
           echo "archive=${GRAFANA_PLUGIN_ARTIFACT}" >> $GITHUB_OUTPUT
 
       - name: Add execute permissions on binary
-        if: needs.build.outputs.has-backend == 'true'
         run: |
           chmod +x ./dist/gpx_*
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
           path: dist/
 
   generate-manifest:
-    needs: [build-linux-amd64, build-macos-arm64, build-windows]
+    needs: [build-linux-amd64, build-linux-arm64, build-macos-arm64, build-windows]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions: read-all
 
 jobs:
   build-linux-amd64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,7 +35,7 @@ jobs:
           path: dist/
 
   build-linux-arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -134,7 +134,7 @@ jobs:
 
   generate-manifest:
     needs: [build-linux-amd64, build-linux-arm64, build-macos-arm64, build-windows]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -165,7 +165,7 @@ jobs:
 
   build:
     name: Build, lint and unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: generate-manifest
     outputs:
       plugin-id: ${{ steps.metadata.outputs.plugin-id }}
@@ -259,7 +259,7 @@ jobs:
 
   resolve-versions:
     name: Resolve e2e images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 3
     needs: build
     if: ${{ needs.build.outputs.has-e2e == 'true' }}
@@ -280,7 +280,7 @@ jobs:
       matrix:
         GRAFANA_IMAGE: ${{fromJson(needs.resolve-versions.outputs.matrix)}}
     name: e2e test ${{ matrix.GRAFANA_IMAGE.name }}@${{ matrix.GRAFANA_IMAGE.VERSION }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
- force include the step to add execute permission to the backend binaries.
- use ubuntu 22.04 instead of latest, which has a slightly too new version of glibc. 
- include linux arm64 build in CI. 