### PR TITLE
Ensure initialization SQL runs only once per DuckDBDriver instance

### DIFF
--- a/pkg/main.go
+++ b/pkg/main.go
@@ -28,6 +28,6 @@ func main() {
 }
 
 func datasourceFactory(ctx context.Context, s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-	ds := plugin.NewDatasource(&plugin.DuckDBDriver{HasSetMotherDuckToken: false})
+	ds := plugin.NewDatasource(&plugin.DuckDBDriver{Initialized: false})
 	return ds.NewDatasource(ctx, s)
 }

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestQueryData(t *testing.T) {
-	ds := NewDatasource(&DuckDBDriver{HasSetMotherDuckToken: false})
+	ds := NewDatasource(&DuckDBDriver{Initialized: false})
 	_, err := ds.NewDatasource(context.Background(), backend.DataSourceInstanceSettings{
 		JSONData: []byte(`{"path":""}`),
 	})
@@ -36,7 +36,7 @@ func TestQueryData(t *testing.T) {
 }
 
 func TestMultipleConcurrentRequests(t *testing.T) {
-	ds := NewDatasource(&DuckDBDriver{HasSetMotherDuckToken: false})
+	ds := NewDatasource(&DuckDBDriver{Initialized: false})
 	ctx := context.Background()
 	_, err := ds.NewDatasource(context.Background(), backend.DataSourceInstanceSettings{
 		JSONData: []byte(`{"path":""}`),
@@ -95,7 +95,7 @@ func TestMultipleConcurrentRequests(t *testing.T) {
 
 func TestMultipleQueriesRequest(t *testing.T) {
 	numQueries := 23
-	ds := NewDatasource(&DuckDBDriver{HasSetMotherDuckToken: false})
+	ds := NewDatasource(&DuckDBDriver{Initialized: false})
 	ctx := context.Background()
 	_, err := ds.NewDatasource(context.Background(), backend.DataSourceInstanceSettings{
 		JSONData: []byte(`{"path":""}`),


### PR DESCRIPTION
## Summary
- Replace `HasSetMotherDuckToken` with `Initialized` flag and mutex for thread safety
- Wrap initialization logic in `\!d.Initialized` check to prevent duplicate execution
- Update tests to use new `Initialized` field

## Test plan
- [x] Run `go test -v ./pkg/plugin` to verify all tests pass
- [x] Verify initialization queries (extensions, directories, MotherDuck token) only execute once per driver instance
- [x] Confirm thread safety with mutex protection around initialization logic

🤖 Generated with [Claude Code](https://claude.ai/code)