### PR TITLE
Fix release GHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ on:
         description: 'Version name (e.g., v1.0.0)'
         required: true
         type: string
-  pull_request:
 
 permissions:
   contents: write


### PR DESCRIPTION
Follow up to #57. The release action had an issue, but it's also hard to test because it requires pushing a tag (okay, not "hard", but making it a manual dispatch is easier).

Seems to work - https://github.com/motherduckdb/grafana-duckdb-datasource/releases/tag/untagged-64e930175a8395f61988