### PR TITLE
Fix: Prevent corruption of escaped quotes during SQL variable interpolation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "duckdb-datasource",
-  "version": "0.4.1",
+  "version": "0.4.0",
   "description": "DuckDB and MotherDuck datasource for grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## Summary
This PR ensures that SQL-escaped single quotes ('') are preserved (instead of collapsed) during template variable interpolation in the DuckDB datasource.

Previously, the interpolation logic would incorrectly collapse these quotes (e.g., select 'a''b' became select 'a'b'), leading to SQL syntax errors.

## Background
Grafana core issue filed: https://github.com/grafana/grafana/issues/117772

## Changes
Override `applyTemplateVariables` to use `SqlQueryModel.interpolate()` without `clean()`, preserving escaped quotes.

## Test
Verified manually in Grafana environment.
`SELECT 'a''b'` no longer results in a parse error.

And, verified that a column name containing a single quote works with variable substitution.

```sql
-- value's query : select 'a''b'

WITH tmp AS (SELECT 999 AS "a'b")
  SELECT "${value:raw}" FROM tmp;
-- returned 999.
```

## Notes
`SqlQueryModel.interpolate()` ensures the variables are swapped, while skipping `clean()` prevents the post-processing step that was over-eagerly stripping the second quote.


