### PR TITLE
chore: rename plugin zip before uploading to draft release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,11 +57,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ZIP_FILE=$(find artifact -name "*.zip" | head -1)
-          echo "Uploading: $ZIP_FILE"
+          RELEASE_VERSION="${VERSION#v}"
+          RENAMED_ZIP="artifact/motherduck-duckdb-datasource-${RELEASE_VERSION}.zip"
+          mv "$ZIP_FILE" "$RENAMED_ZIP"
+          echo "Uploading: $RENAMED_ZIP"
 
           gh release create "$VERSION" \
             --draft \
             --generate-notes \
             --title "$VERSION" \
             -R ${{ github.repository }} \
-            "$ZIP_FILE"
+            "$RENAMED_ZIP"


### PR DESCRIPTION
this worked pretty well -- https://github.com/motherduckdb/grafana-duckdb-datasource/releases/tag/untagged-9fb1fab05dc0be4ca7dd

But because it downloads the last built artifact, the version name is still that of the previous release, so this PR renames it to the new release.