### PR TITLE
fix: limit max open connections to prevent DuckDB resource contention

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "duckdb-datasource",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "DuckDB and MotherDuck datasource for grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "duckdb-datasource",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "DuckDB and MotherDuck datasource for grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -8,9 +8,10 @@ import (
 )
 
 type PluginSettings struct {
-	Path    string                `json:"path"`
-	InitSql string                `json:"initSql"`
-	Secrets *SecretPluginSettings `json:"-"`
+	Path         string                `json:"path"`
+	InitSql      string                `json:"initSql"`
+	MaxOpenConns int                   `json:"maxOpenConns"`
+	Secrets      *SecretPluginSettings `json:"-"`
 }
 
 type SecretPluginSettings struct {

--- a/pkg/plugin/duckdb_driver.go
+++ b/pkg/plugin/duckdb_driver.go
@@ -137,6 +137,12 @@ func (d *DuckDBDriver) Connect(ctx context.Context, settings backend.DataSourceI
 
 	db := sql.OpenDB(connector)
 
+	maxOpen := 25
+	if config.MaxOpenConns > 0 {
+		maxOpen = config.MaxOpenConns
+	}
+	db.SetMaxOpenConns(maxOpen)
+
 	return db, nil
 }
 

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -29,6 +29,16 @@ export function ConfigEditor(props: Props) {
     });
   };
 
+  const onMaxOpenConnsChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(event.target.value, 10);
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...jsonData,
+        maxOpenConns: isNaN(value) ? 0 : value,
+      },
+    });
+  };
 
   // Secure field (only sent to the backend)
   const onMotherDuckTokenChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -73,6 +83,16 @@ export function ConfigEditor(props: Props) {
               width={60}
               rows={5}
           />
+      </InlineField>
+      <InlineField label="Max Connections" labelWidth={20} interactive tooltip={'Maximum number of concurrent database connections (default: 25).'}>
+        <Input
+          id="config-editor-max-open-conns"
+          type="number"
+          onChange={onMaxOpenConnsChange}
+          value={jsonData.maxOpenConns ?? ''}
+          placeholder="25"
+          width={40}
+        />
       </InlineField>
       <InlineField label="MotherDuck Token" labelWidth={20} interactive tooltip={'MotherDuck Token'}>
         <SecretInput

--- a/tests/configEditor.spec.ts
+++ b/tests/configEditor.spec.ts
@@ -28,3 +28,29 @@ test('"Save & test" should fail when configuration is invalid', async ({
   await expect(configPage.saveAndTest()).not.toBeOK();
   await expect(configPage).toHaveAlert('error', { hasText: 'MotherDuck Token is missing for motherduck connection' });
 });
+
+test('"Max Connections" field should be saved and persisted', async ({
+  createDataSourceConfigPage,
+  readProvisionedDataSource,
+  page,
+}) => {
+  const ds = await readProvisionedDataSource<DuckDBDataSourceOptions, SecureJsonData>({ fileName: 'datasources.yml' });
+  const configPage = await createDataSourceConfigPage({ type: ds.type });
+
+  // Fill in required fields
+  await page.getByRole('textbox', { name: 'Database name' }).fill('');
+  await page.getByRole('textbox', { name: 'MotherDuck Token' }).fill('');
+
+  // Set Max Connections value
+  const maxConnsInput = page.getByRole('spinbutton', { name: 'Max Connections' });
+  await expect(maxConnsInput).toBeVisible();
+  await maxConnsInput.fill('10');
+  await expect(maxConnsInput).toHaveValue('10');
+
+  // Save
+  await expect(configPage.saveAndTest()).toBeOK();
+
+  // Reload the page and verify the value is persisted
+  await page.reload();
+  await expect(page.getByRole('spinbutton', { name: 'Max Connections' })).toHaveValue('10');
+});


### PR DESCRIPTION
### Problem

DuckDB is an embedded database that runs in-process. When multiple dashboard panels fire queries simultaneously, each query can spawn a connection, leading to unbounded resource usage and potential contention — especially in environments with many concurrent users or auto-refreshing dashboards.

### Solution

Set `MaxOpenConns` on the `sql.DB` instance after opening the DuckDB connector. A default of **25** is applied, which provides sufficient throughput while preventing excessive resource consumption.

The value is also exposed as a **"Max Connections"** field in the datasource configuration UI, so users can tune it based on their workload.

### Changes

- **settings.go**: Added `MaxOpenConns int` field to `PluginSettings`.
- **duckdb_driver.go**: Call `db.SetMaxOpenConns()` after `sql.OpenDB()`. Defaults to 25 if the setting is unset or 0.
- **ConfigEditor.tsx**: Added a numeric "Max Connections" input field in the config editor.
- **configEditor.spec.ts**: Added an e2e test to verify the field is visible, accepts input, and persists after save and reload.

### Behavior

When the connection pool is exhausted, additional queries wait in Go's `sql.DB` internal queue until a connection becomes available — no queries are dropped.

### Default Value Rationale

DuckDB internally uses multi-threaded execution per query, so 25 concurrent connections is expected to be more than sufficient for typical Grafana dashboard usage while avoiding resource contention.