### PR TITLE
Remove workflow_dispatch from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,17 +3,11 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version name (e.g., v1.0.0)'
-        required: true
-        type: string
   workflow_call:
     inputs:
       version:
         description: 'Version name (e.g., v1.0.0)'
-        required: false
+        required: true
         type: string
 
 permissions:
@@ -24,16 +18,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
     env:
-      VERSION: ${{ inputs.version || github.ref_name }}
+      VERSION: ${{ inputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Create and push tag
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          git tag "$VERSION"
-          git push origin "$VERSION"
 
       - name: Download artifact from CI
         env:


### PR DESCRIPTION
The manual dispatch path was broken: it downloads artifacts from an in-progress CI run on `main`, which only exists when the workflow is called from CI itself. A manual dispatch would fail (or grab a stale run) unless a main CI run happened to be in flight.

Releases go through the version-bump path in `ci.yml` (`check-version-bump` → `deploy` → `workflow_call`), so this removes the dispatch trigger, the dead tag-push step, and the `github.ref_name` fallback, and makes `version` required.