### PR TITLE
Allow annotation queries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 VERSION ?=
 GO_IMAGE ?= golang:1.24-bookworm
 
-.PHONY: dev dist test clean
+.PHONY: dev dist test test-local clean
 
 # Grafana with the plugin on http://localhost:3000
 dev: dist
@@ -22,8 +22,12 @@ else
 	docker build -f dist.Dockerfile --build-arg VERSION=$(VERSION) --output dist .
 endif
 
-# End-to-end tests against a real Grafana, as CI runs them.
+# End-to-end tests, needing nothing but Docker.
 test: dist
+	docker compose run --rm e2e; status=$$?; docker compose down; exit $$status
+
+# The same tests using a local Node.js, as CI runs them.
+test-local: dist
 	npm ci
 	npx playwright install chromium --with-deps
 	docker compose up -d

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+# Set VERSION to run against a published release instead of a local build,
+# e.g. `make dev VERSION=v0.4.5`.
+VERSION ?=
+GO_IMAGE ?= golang:1.24-bookworm
+
+.PHONY: dev dist test clean
+
+# Grafana with the plugin on http://localhost:3000
+dev: dist
+	docker compose up
+
+# Populate ./dist, either from a release or by building this working tree.
+dist:
+ifeq ($(VERSION),)
+	npm ci
+	npm run build
+	docker run --rm -v "$(PWD)":/repo -w /repo -e GOFLAGS=-buildvcs=false $(GO_IMAGE) \
+		sh -c 'go install github.com/magefile/mage@latest && \
+			case $$(uname -m) in aarch64) target=build:LinuxARM64;; *) target=build:Linux;; esac && \
+			mage -v $$target build:GenerateManifestFile'
+else
+	docker build -f dist.Dockerfile --build-arg VERSION=$(VERSION) --output dist .
+endif
+
+# End-to-end tests against a real Grafana, as CI runs them.
+test: dist
+	npm ci
+	npx playwright install chromium --with-deps
+	docker compose up -d
+	until curl -sf http://localhost:3000/api/health >/dev/null; do sleep 1; done
+	npm run e2e; status=$$?; docker compose down; exit $$status
+
+clean:
+	rm -rf dist node_modules playwright-report test-results

--- a/dist.Dockerfile
+++ b/dist.Dockerfile
@@ -1,0 +1,27 @@
+# Populates ./dist with a published release, so Grafana can be run locally
+# without building the plugin. Used by `make dist VERSION=v0.4.5`.
+#
+#   docker build -f dist.Dockerfile --output dist .                          # latest
+#   docker build -f dist.Dockerfile --build-arg VERSION=v0.4.5 --output dist .
+
+FROM alpine:3 AS fetch
+ARG VERSION=latest
+ARG REPO=motherduckdb/grafana-duckdb-datasource
+
+RUN apk add --no-cache curl jq
+
+WORKDIR /out
+RUN set -eu; \
+    tag="$VERSION"; \
+    if [ "$tag" = "latest" ]; then \
+      tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | jq -er .tag_name); \
+    fi; \
+    # Release assets are named without the tag's leading "v".
+    curl -fsSL -o plugin.zip \
+      "https://github.com/${REPO}/releases/download/${tag}/motherduck-duckdb-datasource-${tag#v}.zip"; \
+    unzip -q plugin.zip; \
+    mv motherduck-duckdb-datasource/* .; \
+    rm -rf motherduck-duckdb-datasource plugin.zip
+
+FROM scratch
+COPY --from=fetch /out /

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,3 +29,26 @@ services:
       GF_LOG_LEVEL: info
       GF_DATAPROXY_LOGGING: 1
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: motherduck-duckdb-datasource
+
+  # Playwright with browsers preinstalled, so the e2e tests need no local
+  # Node.js. Kept behind a profile so `docker compose up` is unaffected.
+  # The image tag must track @playwright/test in package.json.
+  e2e:
+    profiles: ['test']
+    image: mcr.microsoft.com/playwright:v1.60.0-noble
+    depends_on:
+      - grafana
+    working_dir: /work
+    environment:
+      GRAFANA_URL: http://grafana:3000
+    volumes:
+      - .:/work
+      # Keeps the container's Linux dependencies out of the host's node_modules.
+      - e2e-node-modules:/work/node_modules
+    command: >
+      bash -c "npm ci &&
+      until curl -sf $$GRAFANA_URL/api/health >/dev/null; do sleep 2; done &&
+      npx playwright test"
+
+volumes:
+  e2e-node-modules:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,7 @@ export default defineConfig<PluginOptions>({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000',
+    baseURL: process.env.GRAFANA_URL ?? 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -6,6 +6,7 @@
   "metrics": true,
   "backend": true,
   "alerting": true,
+  "annotations": true,
   "executable": "gpx_duckdb_datasource",
   "info": {
     "description": "DuckDB and MotherDuck Data source for Grafana",

--- a/tests/annotations.spec.ts
+++ b/tests/annotations.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+const PLUGIN_ID = 'motherduck-duckdb-datasource';
+
+// Grafana's annotation data source picker filters on meta.annotations, which
+// comes straight from plugin.json. Without it the data source is never offered,
+// regardless of what the backend can answer.
+test('advertises annotation support', async ({ page }) => {
+  const settings = await (await page.request.get('/api/frontend/settings')).json();
+  const ds: any = Object.values(settings.datasources).find((d: any) => d.type === PLUGIN_ID);
+
+  expect(ds).toBeDefined();
+  expect(ds.meta.annotations).toBe(true);
+});
+
+test('answers an annotation query with time, text and tags', async ({ page, readProvisionedDataSource }) => {
+  const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+
+  const response = await page.request.post('/api/ds/query', {
+    data: {
+      queries: [
+        {
+          refId: 'anno',
+          // uid is numeric in datasources.yml, but Grafana identifies data sources by string.
+          datasource: { type: ds.type, uid: String(ds.uid) },
+          rawSql: "SELECT now() AS time, 'deploy' AS text, 'ci,prod' AS tags",
+          format: 1, // sqlutil.FormatOptionTable
+        },
+      ],
+      from: 'now-1h',
+      to: 'now',
+    },
+  });
+  expect(response.status(), await response.text()).toBe(200);
+
+  const frame = (await response.json()).results.anno.frames[0];
+  expect(frame.schema.fields.map((f: any) => f.name)).toEqual(['time', 'text', 'tags']);
+  expect(frame.schema.fields[0].type).toBe('time');
+});


### PR DESCRIPTION
This sets `"annotations" = true` in `plugins.json` and adds some helper files:

A `Makefile` that has `dist`, `dev`, `test`, `test-local` and `clean` as targets, where:
- `dist` allows you to build locally with only Docker, but you can also provide a `VERSION` argument that will download a release from GitHub.
- `dev` does a `dist` + spins up Grafana in docker compose.
- `test` runs the E2E tests, needing nothing but Docker.
- `test-local` runs the same tests against a local Node.js, the way CI does.
- `clean` removes built resources.

### Annotations

Grafana's annotation data source picker filters on `meta.annotations`, which comes straight from `plugin.json`. Without it the data source was never offered for annotation queries, even though the backend could already answer them. Verified on Grafana 13.1.3.

Two sharp edges found while writing it, both now encoded in the spec:
- `format` in the query model is a number (`1` = `sqlutil.FormatOptionTable`), not a string.
- `uid: 42` in `datasources.yml` parses as a number, which Grafana rejects with `query.invalidDatasourceId`, hence `String(ds.uid)`.